### PR TITLE
Updates base image to v1.4.2

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -133,3 +133,23 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.cntk-meta.outputs.tags }}
           labels: ${{ steps.cntk-meta.outputs.labels }}
+
+  notify:
+    needs: ["build"]
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' }}
+
+    strategy:
+      matrix:
+        repo:
+          - cloud-native-toolkit/image-github-terraform-runner
+          - cloud-native-toolkit/image-cli-tools-web-terminal
+
+    steps:
+      - name: Repository dispatch ${{ matrix.repo }}
+        uses: cloud-native-toolkit/action-repository-dispatch@main
+        with:
+          notifyRepo: ${{ matrix.repo }}
+          eventType: released
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/update-base-image.yaml
+++ b/.github/workflows/update-base-image.yaml
@@ -1,0 +1,18 @@
+name: Update dependencies
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch
+on:
+  repository_dispatch:
+    types: [ released ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  update:
+    uses: cloud-native-toolkit/action-workflows/.github/workflows/update-base-image.yaml@v1
+    with:
+      repo: ${{ github.event.client_payload.repo }}
+      ref: ${{ github.event.client_payload.ref }}
+      sha: ${{ github.event.client_payload.sha }}
+    secrets:
+      TOKEN: ${{ secrets.TOKEN }}

--- a/Containerfile-alpine
+++ b/Containerfile-alpine
@@ -1,5 +1,5 @@
 ARG TERRAFORM_VERSION=v1.2
-FROM quay.io/cloudnativetoolkit/cli-tools-core:${TERRAFORM_VERSION}-v1.4.1-alpine
+FROM quay.io/cloudnativetoolkit/cli-tools-core:${TERRAFORM_VERSION}-v1.4.2-alpine
 
 ARG TARGETPLATFORM
 

--- a/Containerfile-fedora
+++ b/Containerfile-fedora
@@ -1,5 +1,5 @@
 ARG TERRAFORM_VERSION=v1.2
-FROM quay.io/cloudnativetoolkit/cli-tools-core:${TERRAFORM_VERSION}-v1.4.1-fedora
+FROM quay.io/cloudnativetoolkit/cli-tools-core:${TERRAFORM_VERSION}-v1.4.2-fedora
 
 ARG TARGETPLATFORM
 


### PR DESCRIPTION
- Adds workflow to create a PR when a new version of cli-tools-core is released
- Adds workflow to notify downstream repos when new version is released

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>